### PR TITLE
Tratamento de Erros para Parsing de JSON

### DIFF
--- a/rqc.py
+++ b/rqc.py
@@ -86,10 +86,11 @@ result = execution_status['result']
 if result.startswith("```json"):
     result = result[7:-4].strip()
 
-result_data = json.loads(result)
-
-print(f'\n\033[36mRemote quick command result:\033[0m \n\n{result_data}')
-
-save_output('result', result_data)
-
-print('\n\033[36mOutput saved successfully!\033[0m')
+try:
+    result_data = json.loads(result)
+    print(f'\n\033[36mRemote quick command result:\033[0m \n\n{result_data}')
+    save_output('result', result_data)
+    print('\n\033[36mOutput saved successfully!\033[0m')
+except json.JSONDecodeError as e:
+    print(f'\n\033[31mFailed to parse JSON result:\033[0m {e}')
+    print(f'\n\033[31mRaw result:\033[0m \n\n{result}')


### PR DESCRIPTION
## Introdução de Tratamento de Erros para Parsing de JSON

Este pull request introduz o tratamento de erros para parsing de JSON no script que interage com a API da StackSpot. As seguintes mudanças foram feitas:

### Adição de Bloco try-except:
- Um bloco `try-except` foi adicionado ao redor do código de parsing de JSON (`result_data = json.loads(result)`). Isso garante que quaisquer exceções `json.JSONDecodeError` sejam capturadas e tratadas de forma adequada.

### Mensagens de Erro:
- Se ocorrer um erro de parsing de JSON, uma mensagem de erro será impressa no console, indicando a falha ao parsear o resultado JSON. O resultado bruto também será impresso para ajudar na depuração.